### PR TITLE
Do not fail when error is ENODATA

### DIFF
--- a/src/commands/new-authz.js
+++ b/src/commands/new-authz.js
@@ -94,6 +94,8 @@ async function pollDns (hostname, expected) {
       if (err) {
         if (err.code === 'ENOTFOUND') {
           resolve(false)
+        } else if (err.code === 'ENODATA') {
+          resolve(false)
         } else {
           reject(err)
         }


### PR DESCRIPTION
Without this condition polling doesn't work for me.